### PR TITLE
Fix subscription page formatting

### DIFF
--- a/src/scripts/subscribe.js
+++ b/src/scripts/subscribe.js
@@ -117,7 +117,7 @@ const checkPassword = (password) => {
 }
 
 // Add custom validation to password field
-const passwordField = document.querySelector('#password')
+const passwordField = document.querySelector(`.field-error[data-for='password']`)
 passwordField.addEventListener('blur', event => {
   passwordField.setCustomValidity(checkPassword(event.target.value))
 })
@@ -128,7 +128,7 @@ for (const input of inputs) {
   input.addEventListener('blur', event => {
     // If field is invalid, show validation message
     if (!event.target.checkValidity()) {
-      const errorDisplay = document.querySelector(`label[for=${input.id}] .field-error`)
+      const errorDisplay = document.querySelector(`.field-error[data-for='${input.id}']`)
       if (errorDisplay) {
         errorDisplay.innerHTML = event.target.validationMessage
       }

--- a/src/subscribe/index.html
+++ b/src/subscribe/index.html
@@ -42,32 +42,32 @@
                     </p>
                     <label for="first-name">
                         First Name
-                        <p class="field-error"></p>
                     </label>
+                    <p data-for="first-name" class="field-error"></p>
                     <input id="first-name" name="fname" type="text" placeholder="John" required
                         autocomplete="section-user given-name">
                     <label for="last-name">
                         Last Name
-                        <p class="field-error"></p>
                     </label>
+                    <p data-for="last-name" class="field-error"></p>
                     <input id="last-name" name="lname" type="text" placeholder="Smith" required
                         autocomplete="section-user family-name">
                     <label for="user-email">
                         Email
-                        <p class="field-description">
-                            For signing in and for communication about your account.
-                        </p>
-                        <p class="field-error"></p>
                     </label>
+                    <p class="field-description">
+                        For signing in and for communication about your account.
+                    </p>
+                    <p data-for="user-email" class="field-error"></p>
                     <input id="user-email" name="email" type="email" placeholder="johnsmith@example.com" required
                         autocomplete="section-user home email">
                     <label for="password">
                         Password
-                        <p class="field-description">
-                            Must have at least ten characters and use uppercase, lowercase, numbers, and/or punctuation.
-                        </p>
-                        <p id="password-error" class="field-error"></p>
                     </label>
+                    <p class="field-description">
+                        Must have at least ten characters and use uppercase, lowercase, numbers, and/or punctuation.
+                    </p>
+                    <p data-for="password" class="field-error"></p>
                     <input id="password" name="password" type="password" required minlength="10" maxlength="128"
                         autocomplete="section-user new-password">
                 </section>
@@ -75,17 +75,17 @@
                     <h5>Organization</h5>
                     <label for="organization-name">
                         Name
-                        <p class="field-error"></p>
                     </label>
+                    <p data-for="organization-name" class="field-error"></p>
                     <input id="organization-name" type="text" placeholder="Tipi Productions" required
                         autocomplete="section-organization organization">
                     <label for="organization-email">
                         Email
-                        <p class="field-description">
-                            For communication about your subscription.
-                        </p>
-                        <p class="field-error"></p>
                     </label>
+                    <p class="field-description">
+                        For communication about your subscription.
+                    </p>
+                    <p data-for="organization-email" class="field-error"></p>
                     <input id="organization-email" type="text" placeholder="info@example.com" required
                         autocomplete="section-organization work email">
                     <label for="card-element">


### PR DESCRIPTION
The HTML build task was doing a strange thing to the inputs; putting them inside the `p` tags inside the `label` tags. This is probably because `label` tags are not supposed to contain other block elements.

Closes #23.